### PR TITLE
Add Buttons to Remove Spells

### DIFF
--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -16,6 +16,9 @@ function App () {
   const handleSearch = e => {
     setSearchTerm(e.target.value);
   }
+  const remove = (spell) => {
+    setSpellsToDisplay(spellsToDisplay.filter(s => s.spellName !== spell.spellName))
+  }
 
   useEffect(() => {
     searchTerm === '' && filtersApplied === false ? setSpellsToDisplay(allSpells) :
@@ -34,7 +37,11 @@ function App () {
         <div className="Spellbook"> 
           {spellsToDisplay.length < 1 ? <h2>No Spells Found</h2> :
           spellsToDisplay.map(spell => (
-              <Spell key={spell.id} spell={spell}/>                      
+              <Spell 
+                key={spell.spellName} 
+                spell={spell} 
+                remove={remove}
+              />                      
           ))}
         </div>    
       </div>

--- a/src/Components/Spell/Spell.js
+++ b/src/Components/Spell/Spell.js
@@ -2,25 +2,29 @@ import React, { useState } from "react";
 
 import "./Spell.css";
 
-const Spell = ({spell}) => {
+const Spell = ({spell, remove}) => {
     const [visible, setVisible] = useState(true);
+    const handleRemove = () => {
+        remove(spell)
+    }
 
     return(
 
         <div className='Spellbook-Spell' id={spell.spellName}>
-        <span><h3>{spell.spellName} <img className='SpellsByLevel-Image' src={spell.image} width="100px" alt={spell.spellName} /></h3></span>
-        {visible === true ? 
-            <ul>
-                <li>Spell School: {spell.spellSchool}</li>
-                <li>Casting Time: {spell.castingTime}</li>
-                <li>Range: {spell.range}</li>
-                <li>Attack Type or Save: {spell.attackOrSave}</li>
-                <button onClick={() => setVisible(!visible)}>Hide {spell.spellName} Details</button>
-            </ul>             
-            : 
-            <button onClick={() => setVisible(!visible)}>Show {spell.spellName} Details</button>
-        }
-        <hr></hr>
+            <span><h3>{spell.spellName} <img className='SpellsByLevel-Image' src={spell.image} width="100px" alt={spell.spellName} /></h3></span>
+            {visible === true ? 
+                <ul>
+                    <li>Spell School: {spell.spellSchool}</li>
+                    <li>Casting Time: {spell.castingTime}</li>
+                    <li>Range: {spell.range}</li>
+                    <li>Attack Type or Save: {spell.attackOrSave}</li>
+                    <button onClick={() => setVisible(!visible)}>Hide {spell.spellName} Details</button>
+                </ul>             
+                : 
+                <button onClick={() => setVisible(!visible)}>Show {spell.spellName} Details</button>
+            }
+            <button onClick={handleRemove}>Remove {spell.spellName}</button>
+            <hr></hr>
                             
         </div>
             


### PR DESCRIPTION
This commit adds in remove functionality(in beta form). There is now a 'Remove Spell' button inside each spell component that will remove that spell from the 'spellsToDisplay' array. This functionality will need to be redone after we implement individual spellbooks since the remove will only remove the spell from the spellbook and not from the 'allSpells' array.

Since we don't want to actually remove a spell from the 'allSpells' array, in the current version of the application the spell is displayed again if a spell is searched for and the removed spell meets the search criteria or if the search criteria is cleared out. Once individual spellbooks are implemented then the remove button will actually remove the spell from that spellbook's array of spells so this won't be an issue at that point. Removing spells will only be a feature inside of spellbooks and not available inside the 'allSpells' container(whatever it is called then). 