### PR TITLE
Upgrade filtering to allow for multiple filters

### DIFF
--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -21,8 +21,12 @@ function App () {
   }
 
   useEffect(() => {
-    searchTerm === '' && filtersApplied === false ? setSpellsToDisplay(allSpells) :
-    setSpellsToDisplay(allSpells.filter(spell => spell.spellName.toLowerCase().includes(searchTerm.toLowerCase())))
+    if(searchTerm === '' && filtersApplied === false) {
+        setSpellsToDisplay(allSpells)
+    }
+    else if(searchTerm !== '' && filtersApplied === false) {
+      setSpellsToDisplay(allSpells.filter(spell => spell.spellName.toLowerCase().includes(searchTerm.toLowerCase())))
+    }
   }, [searchTerm])
   
 

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -10,7 +10,7 @@ import Searchbox from '../Searchbox/Searchbox.js';
 function App () {
   
   const [searchTerm, setSearchTerm] = useState('');
-  const [filtersApplied, setFiltersApplied] = useState(false);
+  const [filtersApplied, setFiltersApplied] = useState([]);
   const [filteredSpells, setFilteredSpells] = useState([]);
   const [spellsToDisplay, setSpellsToDisplay] = useState(allSpells);
   const handleSearch = e => {
@@ -21,13 +21,20 @@ function App () {
   }
 
   useEffect(() => {
-    if(searchTerm === '' && filtersApplied === false) {
+    if(searchTerm === '' && filtersApplied.length === 0) {
         setSpellsToDisplay(allSpells)
     }
-    else if(searchTerm !== '' && filtersApplied === false) {
+    else if(searchTerm !== '' && filtersApplied.length === 0) {
       setSpellsToDisplay(allSpells.filter(spell => spell.spellName.toLowerCase().includes(searchTerm.toLowerCase())))
     }
-  }, [searchTerm])
+    else if(searchTerm === '' && filtersApplied.length > 0) {
+      setSpellsToDisplay(filteredSpells)
+    }
+
+    else{
+      setSpellsToDisplay(filteredSpells.filter(spell => spell.spellName.toLowerCase().includes(searchTerm.toLowerCase())))  
+    }
+  }, [searchTerm, filteredSpells, filtersApplied])
   
 
     return (
@@ -37,7 +44,15 @@ function App () {
           <h1 className="Spellbook-Header">Spellbook</h1>
         </div>
         <Searchbox handleSearch={handleSearch} />
-        <FiltersList setSpellsToDisplay={setSpellsToDisplay} spellsToDisplay={spellsToDisplay}/>
+        <FiltersList 
+          setSpellsToDisplay={setSpellsToDisplay} 
+          spellsToDisplay={spellsToDisplay}
+          filtersApplied={filtersApplied}
+          setFiltersApplied={setFiltersApplied}
+          filteredSpells={filteredSpells}
+          setFilteredSpells={setFilteredSpells}
+          allSpells={allSpells}
+        />
         <div className="Spellbook"> 
           {spellsToDisplay.length < 1 ? <h2>No Spells Found</h2> :
           spellsToDisplay.map(spell => (

--- a/src/Components/Filters/Filter.js
+++ b/src/Components/Filters/Filter.js
@@ -1,15 +1,35 @@
 import React, { useState, useEffect } from 'react'
 import allSpells from '../SpellLists/AllSpells'
 
-export default function Filter({filter, setSpellsToDisplay, spellsToDisplay}) {
+export default function Filter({filter, filtersApplied, setFiltersApplied, filteredSpells, setFilteredSpells, allSpells}) {
+    const [filterToRemove, setFilterToRemove] = useState('')
     const [isChecked, setIsChecked] = useState(false)
     const handleFilterClick = e => {
         setIsChecked(!isChecked)
+        if(isChecked === false){
+            setFiltersApplied(Array.from(new Set([...filtersApplied, filter].flat())))
+        }
+        else{
+            setFilterToRemove(filter.displayName);
+            setFiltersApplied(filtersApplied.filter(f => f !== filter))
+        }
+        
     }
     useEffect(() => {
-        isChecked === true ? setSpellsToDisplay(spellsToDisplay.filter(spell => Object.values(spell).includes(filter.displayName))) :
-        setSpellsToDisplay(allSpells)
-      }, [isChecked])
+        console.log(filtersApplied);
+        if(filtersApplied.length === 0) {
+            setFilteredSpells([])
+        }
+        else if(isChecked === true) {
+            let spells = Array.from(new Set([...filteredSpells, allSpells.filter(spell => Object.values(spell).includes(filter.displayName))].flat()));
+            setFilteredSpells(spells);
+        } 
+        else if(isChecked === false && filtersApplied.length > 0 && filterToRemove === filter.displayName) {
+            let spellList = filteredSpells.filter(spell => Object.values(spell).includes(filter.displayName) === false);
+            setFilteredSpells(spellList);
+            setFilterToRemove('');
+        }
+      }, [isChecked, filtersApplied, filterToRemove])
 
     return (
         <div>

--- a/src/Components/Filters/FiltersList.js
+++ b/src/Components/Filters/FiltersList.js
@@ -2,7 +2,7 @@ import React from 'react'
 import Filter from './Filter.js'
 import AllFiltersList from './AllFiltersList.js'
 
-export default function FiltersList({setSpellsToDisplay, spellsToDisplay}) {
+export default function FiltersList({setSpellsToDisplay, spellsToDisplay, filtersApplied, setFiltersApplied, setFilteredSpells, filteredSpells, allSpells}) {
     return (
         <div className='Spellbook-FiltersList'>
             <h1>Filter By: </h1>
@@ -12,6 +12,11 @@ export default function FiltersList({setSpellsToDisplay, spellsToDisplay}) {
                     key={filter.filterName} 
                     setSpellsToDisplay={setSpellsToDisplay}
                     spellsToDisplay={spellsToDisplay}
+                    filtersApplied={filtersApplied}
+                    setFiltersApplied={setFiltersApplied}
+                    filteredSpells={filteredSpells}
+                    setFilteredSpells={setFilteredSpells}
+                    allSpells={allSpells}
                 />
             ))}
         </div>

--- a/src/Components/Spell/Spell.js
+++ b/src/Components/Spell/Spell.js
@@ -15,6 +15,7 @@ const Spell = ({spell, remove}) => {
             {visible === true ? 
                 <ul>
                     <li>Spell School: {spell.spellSchool}</li>
+                    <li>Spell Level: {spell.spellLevel}</li>
                     <li>Casting Time: {spell.castingTime}</li>
                     <li>Range: {spell.range}</li>
                     <li>Attack Type or Save: {spell.attackOrSave}</li>


### PR DESCRIPTION
The previous code allowed some filtering but would not allow for multiple
filters to be used simultaneously in the future. The changes in this commit
allow for much more flexibility in filtering in future versions of the app.**(see
note at bottom)**

This commit allows for multiple filters to be applied but it only really
works if the filters are of the same type(such as 'school' or 'level').
If filters of different types are selected the most recent one will
override the others. Ex: Selecting the 'Abjuration' and 'Conjuration'
filters will disply only abjuration and conjuration spells. If 'Level 1'
is then selected all level 1 spells will be displayed(not just level 1
abjuration or conjuratinspells). More complicated filtering logic will
 be required for that functionality. 'Or' filtering will have to only 
apply to filters of the same type while 'and' filtering will be used 
across multiple types(Selecting 'Abjuration', 'Conjuration', and 
'Level 1' should display spells that are level 1 and either abjuration
or conjuration instead of showing level 1 of all spell schools.

***Note:** _additional testing after the commit showed problems with multiple
filters. These issues only occurred when selecting filters above previously
selected filters in the list. Appears to be due to the useEffect re-running
prior filters when later filters are run._ 